### PR TITLE
Swift Package Manager support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.3
 
 import PackageDescription
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version:5.0
+
+import PackageDescription
+
+let version = "1.4.12"
+// Checksum of the file at `sdkUrl` link. To generate: `swift package compute-checksum build/talkable_ios_sdk.zip`
+let checksum = "a71ababfedb1fa485258a4928ed00891f08cff2c06b77ccddd28f538e192b580"
+let sdkUrl = "https://github.com/talkable/ios-sdk/releases/download/\(version)/talkable_ios_sdk_\(version).zip"
+
+let package = Package(
+    name: "TalkableSDK",
+    platforms: [.iOS(.v9)],
+    products: [
+        .library(
+            name: "TalkableSDK",
+            targets: ["TalkableSDK"]
+        )
+    ],
+    targets: [
+        .binaryTarget(
+            name: "TalkableSDK",
+            url: sdkUrl,
+            checksum: checksum
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -10,24 +10,25 @@ Talkable SDK makes it easy to integrate Talkable referral functionality into iOS
 - [x] iOS 9 or higher.
 
 ## Installation
-### CocoaPods
 
-[CocoaPods](http://cocoapods.org) is a dependency manager for Cocoa projects. You can install it with the following command:
+Talkable supports multiple methods for installing the SDK in a project.
 
-```bash
-$ gem install cocoapods
+### Swift Package Manager
+
+Add Talkable SDK as a dependency to [`Package.swift`](https://www.swift.org/package-manager/) under `dependencies`:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/talkable/ios-sdk.git", .upToNextMajor(from: "1.4.12"))
+]
 ```
 
-To integrate TalkableSDK into your Xcode project using CocoaPods, specify it in your [`Podfile`](https://guides.cocoapods.org/using/the-podfile.html):
+### CocoaPods
+
+To integrate Talkable SDK into your Xcode project using CocoaPods, specify it in your [`Podfile`](https://guides.cocoapods.org/using/the-podfile.html):
 
 ```ruby
 pod 'TalkableSDK'
-```
-
-Then, run the following command:
-
-```bash
-$ pod install
 ```
 
 ## Manual building

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ dependencies: [
 To integrate Talkable SDK into your Xcode project using CocoaPods, specify it in your [`Podfile`](https://guides.cocoapods.org/using/the-podfile.html):
 
 ```ruby
-pod 'TalkableSDK'
+pod 'TalkableSDK', '~> 1.4.12'
 ```
 
 ## Manual building

--- a/Rakefile
+++ b/Rakefile
@@ -27,6 +27,11 @@ module Rake
       run "cd #{TMP_DIR} && zip -r #{filename} ./*"
       File.join(TMP_DIR, filename)
     end
+
+    def info_text(text)
+      yellow_collor_code = 33
+      puts "\e[#{yellow_collor_code}m#{text}\e[0m"
+    end
   end
 end
 
@@ -66,4 +71,5 @@ task archive: :compress do
   puts '*'*20
   puts SDK_ARCHIVE
   puts '*'*20
+  info_text "NOTE: When updating the SDK version, make sure to actualize configuration in TalkableSDK.podspec and Package.swift files (version, checksum etc) and create a correspond release at Github."
 end

--- a/Rakefile
+++ b/Rakefile
@@ -29,8 +29,8 @@ module Rake
     end
 
     def info_text(text)
-      yellow_collor_code = 33
-      puts "\e[#{yellow_collor_code}m#{text}\e[0m"
+      yellow_color_code = 33
+      puts "\e[#{yellow_color_code}m#{text}\e[0m"
     end
   end
 end
@@ -71,5 +71,5 @@ task archive: :compress do
   puts '*'*20
   puts SDK_ARCHIVE
   puts '*'*20
-  info_text "NOTE: When updating the SDK version, make sure to actualize configuration in TalkableSDK.podspec and Package.swift files (version, checksum etc) and create a correspond release at Github."
+  info_text "NOTE: When updating the SDK version, make sure to actualize configuration in TalkableSDK.podspec and Package.swift files (version, checksum etc.) and create a corresponding release in GitHub."
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Added [Swift Package Manager](https://www.swift.org/package-manager/) support as a distribution method of Talkable SDK requested in #13.
The SDK is distributed with SPM as [Binary Framework (XCFramework)](https://developer.apple.com/documentation/xcode/distributing-binary-frameworks-as-swift-packages): the same binary is used for the manual distribution of the SDK.

## Related Stories
<!--- If this pull request is related to JIRA story, please link to the story here -->
[![](http://proxies.talkable.com/talkable/PR-16730)](https://talkable.atlassian.net/browse/PR-16730)

